### PR TITLE
Add manual Remotion project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Node-related
+node_modules/
+remotion/node_modules/
+remotion/.cache/
+remotion/dist/
+remotion/out/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# Editor files
+.DS_Store
+.idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # mionproject
-mion Singer Fansite
+
+mion Singer Fansite と Remotion プロジェクト。
+
+## Web サイト
+
+静的サイトは `index.html` と `styles.css` にまとめています。ファイルをブラウザで直接開くと閲覧できます。
+
+## Remotion イントロ映像
+
+`remotion/` ディレクトリに Remotion を使ったオープニング映像プロジェクトを追加しました。`npx create-video@latest` が使えない環境でも手動で同等の構成を作成しています。
+
+実行手順は `remotion/README.md` を参照してください。

--- a/remotion/README.md
+++ b/remotion/README.md
@@ -1,0 +1,54 @@
+# Remotion プロジェクト
+
+澪音ファンサイトの世界観に合わせたオープニング映像を作るための Remotion プロジェクトです。`npx create-video@latest` が使えない環境でも同じ構成を手作業で再現しています。
+
+## セットアップ
+
+1. Node.js 18 以降をインストールしてください。
+2. 必要なパッケージをインストールします。
+
+   ```bash
+   cd remotion
+   npm install
+   ```
+
+   ※ この環境では npm レジストリへのアクセス制限によりインストールできません。ネットワークに接続できる環境で実行してください。
+
+## 利用方法
+
+開発サーバー (Remotion Studio) を起動するには次のコマンドを実行します。
+
+```bash
+npm run start
+```
+
+ブラウザで `http://localhost:3001` を開くと、コンポジション `MionOpening` をプレビューできます。
+
+ビデオをレンダリングする場合は以下を実行します。
+
+```bash
+npm run build
+```
+
+`out/` ディレクトリに H.264 コーデックの mp4 ファイルが生成されます。
+
+## コンポジション概要
+
+- **MionOpening**: 澪音の象徴アイコンを中心に、夜明けのブルートーンと音の波形をアニメーションで表現した 20 秒のイントロ映像です。プロップでタイトルとサブタイトルのテキストを差し替えることができます。
+- 使用しているアセットは `public/assets/mion-icon.svg` で、ファンサイトのロゴを共有しています。
+
+## ファイル構成
+
+```
+remotion/
+├── public/            # 静的アセット
+├── src/               # Remotion コンポジション
+│   ├── index.ts       # registerRoot のエントリ
+│   ├── Root.tsx       # Composition 定義
+│   └── MionOpening.tsx # メインの映像コンポジション
+├── remotion.config.ts # レンダリング設定
+├── tsconfig.json      # TypeScript 設定
+└── vite.config.ts     # Vite 設定
+```
+
+必要に応じて `src/` に別のコンポジションを追加し、`Root.tsx` の `Composition` を増やすことで拡張できます。

--- a/remotion/package.json
+++ b/remotion/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "mion-remotion",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Remotion video project for the 澪音 fansite.",
+  "scripts": {
+    "start": "remotion studio --port=3001",
+    "preview": "remotion preview",
+    "build": "remotion render --composition=MionOpening --codec=h264",
+    "upgrade": "npx remotion upgrade"
+  },
+  "dependencies": {
+    "@remotion/cli": "^4.0.0",
+    "remotion": "^4.0.0",
+    "zod": "^3.22.0"
+  },
+  "devDependencies": {
+    "@remotion/eslint-config": "^4.0.0",
+    "@types/node": "^20.11.0",
+    "@types/react": "^18.2.14",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.2.0",
+    "eslint": "^8.56.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "typescript": "^5.3.0",
+    "vite": "^5.1.0"
+  }
+}

--- a/remotion/public/assets/mion-icon.svg
+++ b/remotion/public/assets/mion-icon.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title desc">
+  <title id="title">Mion Crest</title>
+  <desc id="desc">Abstract wave crest inspired by the artist Mion</desc>
+  <defs>
+    <radialGradient id="mionGlow" cx="50%" cy="38%" r="70%">
+      <stop offset="0%" stop-color="#ffd9ff" />
+      <stop offset="45%" stop-color="#8aa3ff" />
+      <stop offset="100%" stop-color="#1b1240" />
+    </radialGradient>
+    <linearGradient id="mionWave" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#a0f5ff" />
+      <stop offset="50%" stop-color="#7a74ff" />
+      <stop offset="100%" stop-color="#ff76c9" />
+    </linearGradient>
+    <filter id="softGlow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="3" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="256" height="256" rx="56" fill="url(#mionGlow)" />
+  <g filter="url(#softGlow)">
+    <path d="M48 170c22-62 62-108 124-116 18-2 36 2 52 10-20-32-54-54-92-54-66 0-120 54-120 120 0 26 8 50 22 70 0 0 12-19 14-30z" fill="#2b174c" opacity="0.55" />
+    <path d="M62 182c28-74 90-98 120-92 22 4 38 18 42 42-30-28-74-18-106 6-18 14-36 34-40 64-6 0-12-8-16-20z" fill="#100826" opacity="0.65" />
+    <path d="M74 188c0-36 32-80 76-94 32-10 62 0 76 30-20-10-52-6-72 18-18 20-22 46-12 66-32 4-68-2-68-20z" fill="url(#mionWave)" />
+    <path d="M94 206c0-18 16-36 34-42 16-6 32 0 42 10-16-4-30 4-34 18-4 10 0 20 6 26-20 4-48 0-48-12z" fill="#e4f4ff" opacity="0.8" />
+  </g>
+  <circle cx="204" cy="62" r="18" fill="#ffffff" opacity="0.85" />
+  <circle cx="204" cy="62" r="11" fill="#6e8bff" opacity="0.9" />
+</svg>

--- a/remotion/remotion.config.ts
+++ b/remotion/remotion.config.ts
@@ -1,0 +1,6 @@
+import {Config} from "remotion";
+
+Config.setVideoImageFormat("jpeg");
+Config.setDefaultCodec("h264");
+Config.setOverwriteOutput(true);
+Config.setChromiumOpenGlRenderer("angle");

--- a/remotion/src/MionOpening.tsx
+++ b/remotion/src/MionOpening.tsx
@@ -1,0 +1,174 @@
+import {AbsoluteFill, Img, interpolate, staticFile, useCurrentFrame, useVideoConfig, spring} from "remotion";
+import type {FC} from "react";
+
+type MionOpeningProps = {
+  title: string;
+  subtitle: string;
+};
+
+const AccentRings: FC<{frame: number; fps: number}> = ({frame, fps}) => {
+  const scale = spring({
+    frame,
+    fps,
+    config: {
+      damping: 200,
+    },
+  });
+
+  const opacity = interpolate(frame, [0, 120], [0, 0.25], {
+    extrapolateRight: "clamp",
+  });
+
+  return (
+    <div
+      style={{
+        position: "absolute",
+        width: 800,
+        height: 800,
+        borderRadius: "50%",
+        border: "1px solid rgba(255, 255, 255, 0.5)",
+        transform: `scale(${1 + scale * 0.05})`,
+        opacity,
+        top: "50%",
+        left: "50%",
+        marginLeft: -400,
+        marginTop: -400,
+        filter: "blur(0.5px)",
+      }}
+    />
+  );
+};
+
+const Waveform: FC<{frame: number; fps: number}> = ({frame, fps}) => {
+  const waveOffset = interpolate(frame, [0, fps * 4], [0, Math.PI * 4]);
+  const bars = new Array(60).fill(null);
+
+  return (
+    <div
+      style={{
+        position: "absolute",
+        bottom: 160,
+        width: "70%",
+        left: "15%",
+        display: "flex",
+        justifyContent: "space-between",
+        opacity: interpolate(frame, [40, 80], [0, 0.8], {extrapolateRight: "clamp"}),
+      }}
+    >
+      {bars.map((_, index) => {
+        const x = index / bars.length;
+        const height = 60 + Math.sin(waveOffset + x * Math.PI * 2) * 40;
+        return (
+          <div
+            key={index}
+            style={{
+              width: "1.5%",
+              minWidth: 6,
+              borderRadius: 8,
+              height,
+              background: "linear-gradient(180deg, rgba(255,255,255,0.9), rgba(168,219,255,0.4))",
+              boxShadow: "0 6px 16px rgba(50, 140, 240, 0.25)",
+            }}
+          />
+        );
+      })}
+    </div>
+  );
+};
+
+export const MionOpening: FC<MionOpeningProps> = ({title, subtitle}) => {
+  const frame = useCurrentFrame();
+  const {fps} = useVideoConfig();
+
+  const heroOpacity = spring({frame, fps, delay: 10, config: {damping: 200}});
+  const subtitleY = interpolate(frame, [35, 80], [60, 0], {extrapolateRight: "clamp"});
+  const glow = interpolate(frame, [0, 150], [0.35, 0.6], {extrapolateRight: "clamp"});
+
+  return (
+    <AbsoluteFill
+      style={{
+        background: "radial-gradient(circle at top, #1f7acb 0%, #0b1024 55%, #02030a 100%)",
+        color: "white",
+        fontFamily: "'Noto Sans JP', 'Hiragino Kaku Gothic ProN', sans-serif",
+      }}
+    >
+      <AbsoluteFill
+        style={{
+          background: "linear-gradient(135deg, rgba(140,196,255,0.22) 0%, rgba(19,36,77,0.65) 60%, rgba(2,5,15,0.95) 100%)",
+          mixBlendMode: "screen",
+        }}
+      />
+
+      <AccentRings frame={frame} fps={fps} />
+
+      <AbsoluteFill
+        style={{
+          justifyContent: "center",
+          alignItems: "center",
+          textAlign: "center",
+          padding: "0 120px",
+          filter: `drop-shadow(0 0 120px rgba(82, 186, 255, ${glow}))`,
+        }}
+      >
+        <Img
+          src={staticFile("assets/mion-icon.svg")}
+          style={{
+            width: 220,
+            height: 220,
+            marginBottom: 60,
+            opacity: interpolate(frame, [0, 25], [0, 1], {extrapolateRight: "clamp"}),
+          }}
+        />
+        <h1
+          style={{
+            fontSize: 110,
+            letterSpacing: "0.35em",
+            textTransform: "uppercase",
+            margin: 0,
+            opacity: heroOpacity,
+          }}
+        >
+          MION
+        </h1>
+        <p
+          style={{
+            marginTop: 24,
+            fontSize: 42,
+            letterSpacing: "0.08em",
+            opacity: heroOpacity,
+          }}
+        >
+          {title}
+        </p>
+        <p
+          style={{
+            marginTop: 28,
+            fontSize: 32,
+            fontWeight: 300,
+            opacity: interpolate(frame, [40, 85], [0, 1], {extrapolateRight: "clamp"}),
+            transform: `translateY(${subtitleY}px)`
+          }}
+        >
+          {subtitle}
+        </p>
+      </AbsoluteFill>
+
+      <Waveform frame={frame} fps={fps} />
+
+      <div
+        style={{
+          position: "absolute",
+          bottom: 72,
+          width: "100%",
+          textAlign: "center",
+          fontSize: 26,
+          letterSpacing: "0.4em",
+          textTransform: "uppercase",
+          opacity: interpolate(frame, [80, 140], [0, 0.75], {extrapolateRight: "clamp"}),
+        }}
+      >
+        Suno Collaboration 2024
+      </div>
+    </AbsoluteFill>
+  );
+};

--- a/remotion/src/Root.tsx
+++ b/remotion/src/Root.tsx
@@ -1,0 +1,21 @@
+import {Composition} from "remotion";
+import {MionOpening} from "./MionOpening";
+
+export const RemotionRoot: React.FC = () => {
+  return (
+    <>
+      <Composition
+        id="MionOpening"
+        component={MionOpening}
+        width={1920}
+        height={1080}
+        durationInFrames={600}
+        fps={30}
+        defaultProps={{
+          title: "Echoes of Dawn",
+          subtitle: "透明な歌声で紡ぐ、未来のポップス",
+        }}
+      />
+    </>
+  );
+};

--- a/remotion/src/index.ts
+++ b/remotion/src/index.ts
@@ -1,0 +1,4 @@
+import {registerRoot} from "remotion";
+import {RemotionRoot} from "./Root";
+
+registerRoot(RemotionRoot);

--- a/remotion/tsconfig.base.json
+++ b/remotion/tsconfig.base.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "noEmit": true,
+    "skipLibCheck": true
+  }
+}

--- a/remotion/tsconfig.json
+++ b/remotion/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "module": "esnext",
+    "target": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "baseUrl": "."
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "out"]
+}

--- a/remotion/vite.config.ts
+++ b/remotion/vite.config.ts
@@ -1,0 +1,6 @@
+import {defineConfig} from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- add a manually scaffolded Remotion project that mirrors the create-video starter
- implement the MionOpening composition featuring the existing site branding
- document setup and usage instructions for the video project and update the root README

## Testing
- not run (npm registry access is blocked in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d6b99bcf648323b0f20fcdcbe3db06